### PR TITLE
Add render-to-disk binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN ./hack/build-go.sh
 
 FROM scratch
 COPY --from=build-env /go/src/github.com/openshift/openshift-network-operator/_output/linux/amd64/openshift-network-operator /bin/openshift-network-operator
+COPY --from=build-env /go/src/github.com/openshift/openshift-network-operator/_output/linux/amd64/openshift-network-renderer /bin/openshift-network-renderer
 COPY manifests /manifests
 
 ENV OPERATOR_NAME=openshift-network-operator
-ENTRYPOINT ["/bin/openshift-network-operator"]
+CMD ["/bin/openshift-network-operator"]

--- a/cmd/openshift-network-renderer/main.go
+++ b/cmd/openshift-network-renderer/main.go
@@ -1,0 +1,108 @@
+package main
+
+// Render all created objects to disk, rather than directly to the apiserver.
+// This is used for bootstrapping / install
+
+import (
+	"fmt"
+	"os"
+
+	netv1 "github.com/openshift/openshift-network-operator/pkg/apis/networkoperator/v1"
+	netop "github.com/openshift/openshift-network-operator/pkg/operator"
+
+	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func main() {
+	err := render()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func render() error {
+	var configPath string
+	var outPath string
+	var manifestPath string
+
+	pflag.StringVar(&configPath, "config", "", "json or yaml representation of NetworkConfig object")
+	pflag.StringVar(&outPath, "out", "", "file to put rendered manifests")
+	pflag.StringVar(&manifestPath, "manifests", "./manifests", "directory containing network manifests")
+	pflag.Parse()
+
+	if configPath == "" {
+		logrus.Error("--config must be specified")
+	}
+	if outPath == "" {
+		logrus.Error("--out must be specified")
+	}
+
+	conf, err := readConfigObject(configPath)
+	if err != nil {
+		return err
+	}
+
+	handler := netop.MakeHandler(manifestPath)
+	handler.SetConfig(conf)
+
+	objs, err := handler.Render()
+	if err != nil {
+		return err
+	}
+
+	err = writeObjects(outPath, objs)
+	return err
+}
+
+// readConfigObject reads a NetworkConfig object from disk
+func readConfigObject(path string) (*netv1.NetworkConfig, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to open NetworkConfig file %s", path)
+	}
+
+	decoder := k8syaml.NewYAMLOrJSONDecoder(f, 4096)
+	conf := netv1.NetworkConfig{}
+	if err := decoder.Decode(&conf); err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal NetworkConfig")
+	}
+
+	return &conf, nil
+}
+
+// writeObjects serializes the list of objects as a single yaml file
+func writeObjects(path string, objs []*uns.Unstructured) error {
+	fp, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return errors.Wrapf(err, "could not open output file %s", path)
+	}
+	defer fp.Close()
+
+	for _, obj := range objs {
+		b, err := yaml.Marshal(obj)
+		if err != nil {
+			return errors.Wrapf(err, "could not marshal object %s %s %s",
+				obj.GroupVersionKind().String(),
+				obj.GetNamespace(),
+				obj.GetName())
+		}
+
+		if _, err := fmt.Fprintln(fp, "\n---"); err != nil {
+			return errors.Wrap(err, "write failed")
+		}
+		if _, err := fp.Write(b); err != nil {
+			return errors.Wrap(err, "write failed")
+		}
+	}
+
+	if err := fp.Close(); err != nil {
+		return errors.Wrapf(err, "close failed")
+	}
+	return nil
+}

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPO=github.com/openshift/openshift-network-operator
-WHAT=${WHAT:-openshift-network-operator}
+CMDS=${CMDS:-openshift-network-operator openshift-network-renderer}
 GOFLAGS=${GOFLAGS:-}
 GLDFLAGS=${GLDFLAGS:-}
 
@@ -30,5 +30,7 @@ fi
 
 mkdir -p ${BIN_PATH}
 
-echo "Building ${REPO}/cmd/${WHAT} (${VERSION})"
-CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o ${BIN_PATH}/${WHAT} ${REPO}/cmd/${WHAT}
+for cmd in ${CMDS}; do
+	echo "Building ${REPO}/cmd/${cmd} (${VERSION})"
+	CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o ${BIN_PATH}/${cmd} ${REPO}/cmd/${cmd}
+done


### PR DESCRIPTION
This adds a separate mode that works entirely offline - it consumes configuration from disk, and writes a single yaml file with all desired objects.